### PR TITLE
Increased security by using EncryptedSharedPreferences on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,7 @@ import groovy.json.JsonSlurper
 
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = '28.0.3'
-def DEFAULT_MIN_SDK_VERSION = 16
+def DEFAULT_MIN_SDK_VERSION = 23
 def DEFAULT_TARGET_SDK_VERSION = 28
 
 def safeExtGet(prop, fallback) {
@@ -86,6 +86,7 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"  // From node_modules
+    implementation "androidx.security:security-crypto:1.0.0-alpha02"
 }
 
 def configureReactNativePom(def pom) {

--- a/android/src/main/java/com/emeraldsanto/encryptedstorage/RNEncryptedStorageModule.kt
+++ b/android/src/main/java/com/emeraldsanto/encryptedstorage/RNEncryptedStorageModule.kt
@@ -1,8 +1,9 @@
 package com.emeraldsanto.encryptedstorage
 
-import android.content.Context
 import android.content.SharedPreferences
 import android.content.res.Resources
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
@@ -18,7 +19,13 @@ class RNEncryptedStorageModule(context : ReactApplicationContext) : ReactContext
     private val sharedPreferences : SharedPreferences;
 
     init {
-        this.sharedPreferences = context.getSharedPreferences(RNEncryptedStorageModule.SHARED_PREFERENCES_FILENAME, Context.MODE_PRIVATE)
+        this.sharedPreferences = EncryptedSharedPreferences.create(
+            RNEncryptedStorageModule.SHARED_PREFERENCES_FILENAME,
+            MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
+            context,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        );
     }
 
     override fun getName(): String {


### PR DESCRIPTION
This raised the `minSdkVersion` to 23 from 18. I think that's a necessary drawback in order to provide more secure access to the storage engine. 