### PR TITLE
Adapated API to match AsyncStorage, support for callbacks

### DIFF
--- a/lib/EncryptedStorage.js
+++ b/lib/EncryptedStorage.js
@@ -11,38 +11,50 @@ const EncryptedStorage = {
      * @param {string} key - A string that will be associated to the value for later retrieval.
      * @param {Object} value - The data to store.
      */
-    setItem: async function (key, value) {
-        try {
-            await RNEncryptedStorage.setItem(key, JSON.stringify(value));
-            return true;
-        } catch (error) {
-            return false;
-        }
+    setItem: async function (key, value, cb) {
+        return new Promise(async (resolve, reject) => {
+            try {
+                await RNEncryptedStorage.setItem(key, value);
+                cb && cb(null);
+                resolve(null);
+            } catch (error) {
+                cb && cb(error);
+                reject(error);
+            }
+        });
     },
 
     /**
      * Retrieves data from the disk, using SharedPreferences or KeyChain, depending on the platform and returns it as the specified type.
      * @param {string} key - A string that is associated to a value.
      */
-    getItem: async function (key) {
-        try {
-            return await RNEncryptedStorage.getItem(key);
-        } catch (error) {
-            return undefined;
-        }
+    getItem: async function (key, cb) {
+        return new Promise(async (resolve, reject) => {
+            try {
+                const value = await RNEncryptedStorage.getItem(key);
+                cb && cb(null, value);
+                resolve(value);
+            } catch (error) {
+                cb && cb(error, null);
+                reject(error);
+            }
+        });
     },
 
     /**
      * Deletes data from the disk, using SharedPreferences or KeyChain, depending on the platform.
      * @param {string} key - A string that is associated to a value.
      */
-    removeItem: async function (key) {
-        try {
-            await RNEncryptedStorage.removeItem(key);
-            return true;
-        } catch (error) {
-            return false;
-        }
+    removeItem: async function (key, cb) {
+        return new Promise(async (resolve, reject) => {
+            try {
+                await RNEncryptedStorage.removeItem(key);
+                cb && cb(null);
+                resolve(null);
+            } catch (error) {
+                reject(error);
+            }
+        }); 
     }
 }
 

--- a/lib/EncryptedStorage.test.js
+++ b/lib/EncryptedStorage.test.js
@@ -3,46 +3,128 @@ const { NativeModules } = require('react-native');
 const { RNEncryptedStorage } = NativeModules;
 
 describe('lib/EncryptedStorage', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
 
-  describe('setItem(key, value)', () => {
-    it('should return true if it could store the value', async () => {
-      const storeResult = await EncryptedStorage.setItem('keyName', 'value');
-      expect(storeResult).toBe(true);
-    });
+	describe('using Promises', () => {
+		describe('setItem(key, value)', () => {
+			it('should return no errors if it could store the value', async () => {
+				const storeError = await EncryptedStorage.setItem('key', 'value');
+				expect(storeError).toBe(null);
+			});
+	
+			it('should reject with an error if it could not store the value', async () => {
+				RNEncryptedStorage.setItem.mockImplementationOnce(() => Promise.reject(new Error('Set error')));
+	
+				try {
+					await EncryptedStorage.setItem('key', 'value');
+				} catch (error) {
+					expect(error.message).toBe('Set error');
+				}
+			});
+		});
+	
+		describe('getItem(key)', () => {
+			it('should return the value if it could be retrieved succesfully', async () => {
+				const item = await EncryptedStorage.getItem('key');
+				expect(item).toEqual('{ "foo": 1 }');
+			});
+	
+			it('should return null if no value was found for that key', async () => {
+				RNEncryptedStorage.getItem.mockImplementationOnce(() => Promise.resolve(undefined));
+	
+				const item = await EncryptedStorage.getItem('key');
+				expect(item).toEqual(undefined);
+			});
+	
+			it('should reject with an error if it could not retrieve the value', async () => {
+				RNEncryptedStorage.getItem.mockImplementationOnce(() => Promise.reject(new Error("Get error")));
+				
+				try {
+					await EncryptedStorage.getItem('key');
+				} catch (error) {
+					expect(error.message).toBe('Get error');
+				}
+			});
+		});	
+	
+		describe('removeItem(key)', () => {
+			it('should return no error if it could removed the stored value', async () => {
+				const removeResult = await EncryptedStorage.removeItem('key');
+				expect(removeResult).toBe(null);
+			});
+	
+			it('should throw an error if it could not retrieve the stored value', async () => {
+				RNEncryptedStorage.removeItem.mockImplementationOnce(() => Promise.reject(new Error("Remove error")));
+	
+				try {
+					await EncryptedStorage.removeItem('key');
+				} catch (error) {
+					expect(error.message).toBe('Remove error');
+				}
+			});
+		});
+	});
 
-    it('should return false if it could not store the value', async () => {
-      RNEncryptedStorage.setItem.mockImplementationOnce(() => Promise.reject());
-      const storeResult = await EncryptedStorage.setItem('keyName', 'value');
-      expect(storeResult).toBe(false);
-    });
-  });
+	describe('using callbacks', () => {
+		describe('setItem(key, value)', () => {
+			it('should return no errors if it could store the value', () => {
+				EncryptedStorage.setItem('key', 'value', err => {
+					expect(err).toBe(null);
+				});
+			});
+	
+			it('should reject with an error if it could not store the value', () => {
+				RNEncryptedStorage.setItem.mockImplementationOnce(() => Promise.reject(new Error('Set error')));
 
-  describe('getItem(key)', () => {
-    it('should return the value if it could be retrieved succesfully', async () => {
-      const storeResult = await EncryptedStorage.getItem('keyName');
-      expect(storeResult).toEqual('{ "foo": 1 }');
-    });
-
-    it('should return undefined if it could not retrieve the value', async () => {
-      RNEncryptedStorage.getItem.mockImplementationOnce(() => Promise.reject());
-      const storeResult = await EncryptedStorage.getItem('keyName');
-      expect(storeResult).toBe(undefined);
-    });
-  });
-
-  describe('removeItem(key)', () => {
-    it('should return true if it could remove the stored value', async () => {
-      const storeResult = await EncryptedStorage.removeItem('keyName');
-      expect(storeResult).toBe(true);
-    });
-
-    it('should return false if it could not store the value', async () => {
-      RNEncryptedStorage.removeItem.mockImplementationOnce(() => Promise.reject());
-      const storeResult = await EncryptedStorage.removeItem('keyName');
-      expect(storeResult).toBe(false);
-    });
-  });
+				EncryptedStorage.setItem('key', 'value', err => {
+					expect(err.message).toBe('Set error');
+				});
+			});
+		});
+	
+		describe('getItem(key)', () => {
+			it('should return the value if it could be retrieved succesfully', () => {
+				EncryptedStorage.getItem('key', (err, value) => {
+					expect(err).toBe(null);
+					expect(value).toEqual('{ "foo": 1 }');
+				});
+			});
+	
+			it('should return null if no value was found for that key', () => {
+				RNEncryptedStorage.getItem.mockImplementationOnce(() => Promise.resolve(undefined));
+	
+				EncryptedStorage.getItem('key', (err, value) => {
+					expect(err).toBe(null);
+					expect(value).toBe(undefined);
+				});
+			});
+	
+			it('should reject with an error if it could not retrieve the value', () => {
+				RNEncryptedStorage.getItem.mockImplementationOnce(() => Promise.reject(new Error("Get error")));
+				
+				EncryptedStorage.getItem('key', (err, value) => {
+					expect(err.message).toEqual('Get error');
+					expect(value).toBe(undefined);
+				});
+			});
+		});	
+	
+		describe('removeItem(key)', () => {
+			it('should return no error if it could removed the stored value', () => {
+				EncryptedStorage.removeItem('key', err => {
+					expect(err).toBe(null);
+				});
+			});
+	
+			it('should throw an error if it could not retrieve the stored value', () => {
+				RNEncryptedStorage.removeItem.mockImplementationOnce(() => Promise.reject(new Error("Remove error")));
+	
+				EncryptedStorage.removeItem('key', err => {
+					expect(err.message).toBe('Remove error');
+				});
+			});
+		});
+	});
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,19 +8,19 @@ declare module "react-native-encrypted-storage" {
          * @param {string} key - A string that will be associated to the value for later retrieval.
          * @param {Object} value - The data to store.
          */
-        setItem(key : string, value : Object) : Promise<boolean>;
+        setItem(key : string, value : Object, callback? : (error? : Error) => void) : Promise<void>;
 
         /**
          * Retrieves data from the disk, using SharedPreferences or KeyChain, depending on the platform and returns it.
          * @param {string} key - A string that is associated to a value.
          */
-        getItem(key : string) : Promise<string | undefined>;
+        getItem(key : string, callback? : (error? : Error, value? : string) => void) : Promise<string | null>;
 
         /**
          * Deletes data from the disk, using SharedPreferences or KeyChain, depending on the platform.
          * @param {string} key - A string that is associated to a value.
          */
-        removeItem(key : string) : Promise<boolean>;
+        removeItem(key : string, callback? : (error? : Error) => void) : Promise<void>;
     }
 
     const EncryptedStorage : EncryptedStorageStatic;


### PR DESCRIPTION
This PR again introduces breaking changes to match the AsyncStorage API. All functions now support callbacks and will have to be wrapped with `try/catch` when using their `Promise` form.