### PR TITLE
Version 2.3.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,10 +12,10 @@ import groovy.json.JsonSlurper
 //   original location:
 //   - https://github.com/facebook/react-native/blob/0.58-stable/local-cli/templates/HelloWorld/android/app/build.gradle
 
-def DEFAULT_COMPILE_SDK_VERSION = 28
+def DEFAULT_COMPILE_SDK_VERSION = 29
 def DEFAULT_BUILD_TOOLS_VERSION = '28.0.3'
-def DEFAULT_MIN_SDK_VERSION = 23
-def DEFAULT_TARGET_SDK_VERSION = 28
+def DEFAULT_MIN_SDK_VERSION = 1
+def DEFAULT_TARGET_SDK_VERSION = 29
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -35,7 +35,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.5.3'
+            classpath 'com.android.tools.build:gradle:3.6.3'
         }
     }
     repositories {
@@ -53,8 +53,8 @@ android {
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)
         targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)
-        versionCode 1
-        versionName "1.0"
+        versionCode 23
+        versionName "2.3.0"
     }
     lintOptions {
         abortOnError false
@@ -79,7 +79,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
-    implementation "androidx.security:security-crypto:1.0.0-alpha02"
+    implementation "androidx.security:security-crypto:1.0.0-rc02"
 }
 
 def configureReactNativePom(def pom) {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,13 @@
+# Project-wide Gradle settings.
+
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app's APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Feb 10 19:24:35 EST 2020
+#Fri May 29 23:06:02 EDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/android/src/main/java/com/emeraldsanto/encryptedstorage/RNEncryptedStorageModule.java
+++ b/android/src/main/java/com/emeraldsanto/encryptedstorage/RNEncryptedStorageModule.java
@@ -1,7 +1,9 @@
 package com.emeraldsanto.encryptedstorage;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
+import android.os.Build;
 import android.util.Log;
 
 import androidx.security.crypto.EncryptedSharedPreferences;
@@ -23,6 +25,11 @@ public class RNEncryptedStorageModule extends ReactContextBaseJavaModule {
     public RNEncryptedStorageModule(ReactApplicationContext context) {
         super(context);
 
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            this.sharedPreferences = context.getSharedPreferences(RNEncryptedStorageModule.SHARED_PREFERENCES_FILENAME, Context.MODE_PRIVATE);
+            return;
+        }
+
         try {
             this.sharedPreferences = EncryptedSharedPreferences.create(
                 RNEncryptedStorageModule.SHARED_PREFERENCES_FILENAME,
@@ -34,7 +41,7 @@ public class RNEncryptedStorageModule extends ReactContextBaseJavaModule {
         }
 
         catch (Exception ex) {
-            Log.w(RNEncryptedStorageModule.NATIVE_MODULE_NAME, String.format("Could not initialize SharedPreferences - %s", ex.getLocalizedMessage()));
+            this.sharedPreferences = context.getSharedPreferences(RNEncryptedStorageModule.SHARED_PREFERENCES_FILENAME, Context.MODE_PRIVATE);
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://www.github.com/emeraldsanto/react-native-encrypted-storage#readme",
   "scripts": {
     "test": "jest",
-    "prepare": "tsc"
+    "prepare": "npm run test && tsc"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-encrypted-storage",
   "title": "React Native Encrypted Storage",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A React Native wrapper over SharedPreferences and Keychain to provide a secure alternative to Async Storage",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://www.github.com/emeraldsanto/react-native-encrypted-storage#readme",
   "scripts": {
     "test": "jest",
-    "prepublish": "tsc"
+    "prepare": "tsc"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This version includes a decrease in the `minSdkVersion` to from 23, in order to make this happen I simply checked wether or not the `EncryptedSharedPreferences` API is available and when it is not I fall back to normal `SharedPreferences`.