### PR TITLE
Add support for storage options

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,30 @@ async function removeUserSession() {
 }
 ```
 
+### Storage options
+
+You can pass a set of **options** as the previous to last parameter of `setItem`, `getItem`, `removeItem` or `clear` functions:
+
+```js
+await EncryptedStorage.removeItem('user_session', {
+  storageName: 'userStorage',
+});
+```
+
+The following options are supported:
+
+- `keychainAccessibility` (**iOS only**)
+
+  Control item availability relative to the lock state of the device. If the attribute ends with the string `ThisDeviceOnly`, the item can be restored to the same device that created a backup, but it isn’t migrated when restoring another device’s backup data. [Read more](https://developer.apple.com/documentation/security/keychain_services/keychain_items/restricting_keychain_item_accessibility?language=objc)
+
+  Default value: `kSecAttrAccessibleAfterFirstUnlock`
+
+- `storageName`
+
+  A string for identifying a set of storage items. Should not contain path separators. Uses [kSecAttrService](https://developer.apple.com/documentation/security/ksecattrservice?language=objc) on iOS and [fileName](https://developer.android.com/reference/kotlin/androidx/security/crypto/EncryptedSharedPreferences?hl=en#create) on Android.
+
+  Default value: App's bundle id
+
 ## Note regarding `Keychain` persistence
 
 You'll notice that the iOS `Keychain` is not cleared when your app is uninstalled, this is the expected behaviour. However, if you do want to achieve a different behaviour, you can use the below snippet to clear the `Keychain` on the first launch of your app.

--- a/android/src/androidTest/java/com/emeraldsanto/encryptedstorage/MockReadableMap.java
+++ b/android/src/androidTest/java/com/emeraldsanto/encryptedstorage/MockReadableMap.java
@@ -1,0 +1,92 @@
+package com.emeraldsanto.encryptedstorage;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.facebook.react.bridge.Dynamic;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
+import com.facebook.react.bridge.ReadableType;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+class MockReadableMap implements ReadableMap {
+  @Override
+  public boolean getBoolean(@NonNull String name) {
+    return false;
+  }
+
+  @Override
+  public double getDouble(@NonNull String name) {
+    return 0;
+  }
+
+  @Override
+  public int getInt(@NonNull String name) {
+    return 0;
+  }
+
+  @Override
+  public boolean hasKey(@NonNull String name) {
+    return name.equals("storageName");
+  }
+
+  @Override
+  public boolean isNull(@NonNull String name) {
+    return false;
+  }
+
+  @Nullable
+  @Override
+  public String getString(@NonNull String name) {
+    if (name.equals("storageName")) {
+      return "mock.storage.name";
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public ReadableArray getArray(@NonNull String name) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public ReadableMap getMap(@NonNull String name) {
+    return null;
+  }
+
+  @NonNull
+  @Override
+  public Dynamic getDynamic(@NonNull String name) {
+    return null;
+  }
+
+  @NonNull
+  @Override
+  public ReadableType getType(@NonNull String name) {
+    return null;
+  }
+
+  @NonNull
+  @Override
+  public Iterator<Map.Entry<String, Object>> getEntryIterator() {
+    return null;
+  }
+
+  @NonNull
+  @Override
+  public ReadableMapKeySetIterator keySetIterator() {
+    return null;
+  }
+
+  @NonNull
+  @Override
+  public HashMap<String, Object> toHashMap() {
+    return null;
+  }
+}

--- a/android/src/androidTest/java/com/emeraldsanto/encryptedstorage/RNEncryptedStorageModuleUnitTest.java
+++ b/android/src/androidTest/java/com/emeraldsanto/encryptedstorage/RNEncryptedStorageModuleUnitTest.java
@@ -2,8 +2,11 @@ package com.emeraldsanto.encryptedstorage;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
+
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableMap;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,76 +17,77 @@ import static org.mockito.Mockito.verify;
 @RunWith(AndroidJUnit4.class)
 public class RNEncryptedStorageModuleUnitTest {
     private RNEncryptedStorageModule module;
+    private final ReadableMap options = new MockReadableMap();
 
     @Before
     public void setUp() {
         module = new RNEncryptedStorageModule(new ReactApplicationContext(InstrumentationRegistry.getInstrumentation().getTargetContext()));
-        module.clear(mock(Promise.class));
+        module.clear(options, mock(Promise.class));
     }
 
     @Test
     public void shouldGetAndSet() {
         Promise promise1 = mock(Promise.class);
-        module.getItem("test", promise1);
+        module.getItem("test", options, promise1);
         verify(promise1).resolve(null);
 
         Promise promise2 = mock(Promise.class);
-        module.setItem("test", "asd", promise2);
+        module.setItem("test", "asd", options, promise2);
         verify(promise2).resolve("asd");
 
         Promise promise3 = mock(Promise.class);
-        module.getItem("test", promise3);
+        module.getItem("test", options, promise3);
         verify(promise3).resolve("asd");
     }
 
     @Test
     public void shouldRemove() {
         Promise promise1 = mock(Promise.class);
-        module.setItem("test", "asd", promise1);
+        module.setItem("test", "asd", options, promise1);
         verify(promise1).resolve("asd");
 
         Promise promise2 = mock(Promise.class);
-        module.getItem("test", promise2);
+        module.getItem("test", options, promise2);
         verify(promise2).resolve("asd");
 
         Promise promise3 = mock(Promise.class);
-        module.removeItem("test", promise3);
+        module.removeItem("test", options, promise3);
         verify(promise3).resolve("test");
 
         Promise promise4 = mock(Promise.class);
-        module.getItem("test", promise4);
+        module.getItem("test", options, promise4);
         verify(promise4).resolve(null);
     }
 
     @Test
     public void shouldClear() {
         Promise promise1 = mock(Promise.class);
-        module.setItem("test", "asd", promise1);
+        module.setItem("test", "asd", options, promise1);
         verify(promise1).resolve("asd");
 
         Promise promise2 = mock(Promise.class);
-        module.getItem("test", promise2);
+        module.getItem("test", options, promise2);
         verify(promise2).resolve("asd");
 
         Promise promise3 = mock(Promise.class);
-        module.clear(promise3);
+        module.clear(options, promise3);
         verify(promise3).resolve(null);
 
         Promise promise4 = mock(Promise.class);
-        module.getItem("test", promise4);
+        module.getItem("test", options, promise4);
         verify(promise4).resolve(null);
     }
 
     @Test
     public void shouldKeepValuesWhenRecreated() {
         Promise promise1 = mock(Promise.class);
-        module.setItem("test", "asd", promise1);
+        module.setItem("test", "asd", options, promise1);
         verify(promise1).resolve("asd");
 
         module = new RNEncryptedStorageModule(new ReactApplicationContext(InstrumentationRegistry.getInstrumentation().getTargetContext()));
 
         Promise promise2 = mock(Promise.class);
-        module.getItem("test", promise2);
+        module.getItem("test", options, promise2);
         verify(promise2).resolve("asd");
     }
 }

--- a/ios/RNEncryptedStorage.m
+++ b/ios/RNEncryptedStorage.m
@@ -96,15 +96,17 @@ RCT_EXPORT_METHOD(setItem:(NSString *)key withValue:(NSString *)value withOption
 
 RCT_EXPORT_METHOD(getItem:(NSString *)key withOptions:(NSDictionary *) options resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    CFStringRef keychainAccessibility = getKeychainAccessibility(options);
     NSString *keychainService = getKeychainService(options);
+    /*
+         The unique key for kSecClassGenericPassword is composed of: kSecAttrAccount and kSecAttrService
+         https://stackoverflow.com/a/22519700
+     */
     NSDictionary* getQuery = @{
         (__bridge id)kSecClass : (__bridge id)kSecClassGenericPassword,
         (__bridge id)kSecAttrAccount : key,
+        (__bridge id)kSecAttrService: keychainService,
         (__bridge id)kSecReturnData : (__bridge id)kCFBooleanTrue,
-        (__bridge id)kSecMatchLimit : (__bridge id)kSecMatchLimitOne,
-        (__bridge id)kSecAttrAccessible: (__bridge id)keychainAccessibility,
-        (__bridge id)kSecAttrService: keychainService
+        (__bridge id)kSecMatchLimit : (__bridge id)kSecMatchLimitOne
     };
     
     CFTypeRef dataRef = NULL;

--- a/src/EncryptedStorage.test.ts
+++ b/src/EncryptedStorage.test.ts
@@ -1,5 +1,5 @@
 import { NativeModules } from 'react-native';
-import EncryptedStorage from './EncryptedStorage';
+import EncryptedStorage, { EncryptedStorageOptions } from './EncryptedStorage';
 
 const { RNEncryptedStorage } = NativeModules;
 
@@ -87,9 +87,11 @@ describe('lib/EncryptedStorage', () => {
   });
 
   describe('using callbacks', () => {
+    const options: EncryptedStorageOptions = {};
+
     describe('setItem(key, value)', () => {
       it('should return no errors if it could store the value', () => {
-        EncryptedStorage.setItem('key', 'value', (error) => {
+        EncryptedStorage.setItem('key', 'value', options, (error) => {
           expect(error).toBeUndefined();
         });
       });
@@ -99,7 +101,7 @@ describe('lib/EncryptedStorage', () => {
           Promise.reject(new Error('Set error'))
         );
 
-        EncryptedStorage.setItem('key', 'value', (error) => {
+        EncryptedStorage.setItem('key', 'value', options, (error) => {
           expect(error?.message).toEqual('Set error');
         });
       });
@@ -107,7 +109,7 @@ describe('lib/EncryptedStorage', () => {
 
     describe('getItem(key)', () => {
       it('should return the value if it could be retrieved succesfully', () => {
-        EncryptedStorage.getItem('key', (error, value) => {
+        EncryptedStorage.getItem('key', options, (error, value) => {
           expect(error).toBeUndefined();
           expect(value).toEqual('{ "foo": 1 }');
         });
@@ -118,7 +120,7 @@ describe('lib/EncryptedStorage', () => {
           Promise.resolve(undefined)
         );
 
-        EncryptedStorage.getItem('key', (error, value) => {
+        EncryptedStorage.getItem('key', options, (error, value) => {
           expect(error).toBeUndefined();
           expect(value).toBeUndefined();
         });
@@ -129,7 +131,7 @@ describe('lib/EncryptedStorage', () => {
           Promise.reject(new Error('Get error'))
         );
 
-        EncryptedStorage.getItem('key', (error, value) => {
+        EncryptedStorage.getItem('key', options, (error, value) => {
           expect(error?.message).toEqual('Get error');
           expect(value).toBeUndefined();
         });
@@ -138,7 +140,7 @@ describe('lib/EncryptedStorage', () => {
 
     describe('removeItem(key)', () => {
       it('should return no error if it could remove the stored value', () => {
-        EncryptedStorage.removeItem('key', (error) => {
+        EncryptedStorage.removeItem('key', options, (error) => {
           expect(error).toBeUndefined();
         });
       });
@@ -148,7 +150,7 @@ describe('lib/EncryptedStorage', () => {
           Promise.reject(new Error('Remove error'))
         );
 
-        EncryptedStorage.removeItem('key', (error) => {
+        EncryptedStorage.removeItem('key', options, (error) => {
           expect(error?.message).toEqual('Remove error');
         });
       });

--- a/src/EncryptedStorage.test.ts
+++ b/src/EncryptedStorage.test.ts
@@ -158,7 +158,7 @@ describe('lib/EncryptedStorage', () => {
 
     describe('clear()', () => {
       it('should return no error if it could clear the storage', () => {
-        EncryptedStorage.clear((error) => {
+        EncryptedStorage.clear(options, (error) => {
           expect(error).toBeUndefined();
         });
       });
@@ -168,7 +168,7 @@ describe('lib/EncryptedStorage', () => {
           Promise.reject(new Error('Clear error'))
         );
 
-        EncryptedStorage.clear((error) => {
+        EncryptedStorage.clear(options, (error) => {
           expect(error?.message).toEqual('Clear error');
         });
       });

--- a/src/EncryptedStorage.ts
+++ b/src/EncryptedStorage.ts
@@ -10,11 +10,27 @@ if (!RNEncryptedStorage) {
 }
 
 type KeychainAccessibilityKeys = keyof typeof keychainAccessibility;
+
 export type EncryptedStorageOptions = {
   /**
-   * iOS only
+   * **iOS only** - Control item availability relative to the lock state of the device.
+   *
+   * If the attribute ends with the string `ThisDeviceOnly`, the item can be restored to the same device that created a backup,
+   * but it isn’t migrated when restoring another device’s backup data.
+   * [Read more](https://developer.apple.com/documentation/security/keychain_services/keychain_items/restricting_keychain_item_accessibility?language=objc)
+   *
+   * Default value: `kSecAttrAccessibleAfterFirstUnlock`
    */
   keychainAccessibility?: typeof keychainAccessibility[KeychainAccessibilityKeys];
+  /**
+   * A string for identifying a set of storage items. Should not contain path separators.
+   *
+   * Uses [kSecAttrService](https://developer.apple.com/documentation/security/ksecattrservice?language=objc) on iOS
+   * and [fileName](https://developer.android.com/reference/kotlin/androidx/security/crypto/EncryptedSharedPreferences?hl=en#create) on Android.
+   *
+   * Default value: App's bundle id
+   */
+  storageName?: string;
 };
 
 export type StorageErrorCallback = (error?: Error) => void;
@@ -125,19 +141,24 @@ export default class EncryptedStorage {
   /**
    * Clears all data from disk, using SharedPreferences or KeyChain, depending on the platform.
    */
-  static clear(): Promise<void>;
-
+  static clear(options?: EncryptedStorageOptions): Promise<void>;
   /**
    * Clears all data from disk, using SharedPreferences or KeyChain, depending on the platform.
    * @param {Function} cb - The function to call when the operation completes.
    */
-  static clear(cb: StorageErrorCallback): void;
-  static clear(cb?: StorageErrorCallback): void | Promise<void> {
+  static clear(
+    options?: EncryptedStorageOptions,
+    cb?: StorageErrorCallback
+  ): void;
+  static clear(
+    options?: EncryptedStorageOptions,
+    cb?: StorageErrorCallback
+  ): void | Promise<void> {
     if (cb) {
-      RNEncryptedStorage.clear().then(cb).catch(cb);
+      RNEncryptedStorage.clear(options).then(cb).catch(cb);
       return;
     }
 
-    return RNEncryptedStorage.clear();
+    return RNEncryptedStorage.clear(options);
   }
 }

--- a/src/EncryptedStorage.ts
+++ b/src/EncryptedStorage.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-dupe-class-members */
 
 import { NativeModules } from 'react-native';
-import { keychainAccessibility } from './constants';
+import { KeychainAccessibility } from './constants';
 
 const { RNEncryptedStorage } = NativeModules;
 
@@ -9,7 +9,7 @@ if (!RNEncryptedStorage) {
   throw new Error('RNEncryptedStorage is undefined');
 }
 
-type KeychainAccessibilityKeys = keyof typeof keychainAccessibility;
+type KeychainAccessibilityKeys = keyof typeof KeychainAccessibility;
 
 export type EncryptedStorageOptions = {
   /**
@@ -21,7 +21,7 @@ export type EncryptedStorageOptions = {
    *
    * Default value: `kSecAttrAccessibleAfterFirstUnlock`
    */
-  keychainAccessibility?: typeof keychainAccessibility[KeychainAccessibilityKeys];
+  keychainAccessibility?: typeof KeychainAccessibility[KeychainAccessibilityKeys];
   /**
    * A string for identifying a set of storage items. Should not contain path separators.
    *

--- a/src/EncryptedStorage.ts
+++ b/src/EncryptedStorage.ts
@@ -1,11 +1,21 @@
 /* eslint-disable no-dupe-class-members */
 
 import { NativeModules } from 'react-native';
+import { keychainAccessibility } from './constants';
+
 const { RNEncryptedStorage } = NativeModules;
 
 if (!RNEncryptedStorage) {
   throw new Error('RNEncryptedStorage is undefined');
 }
+
+type KeychainAccessibilityKeys = keyof typeof keychainAccessibility;
+export type EncryptedStorageOptions = {
+  /**
+   * iOS only
+   */
+  keychainAccessibility?: typeof keychainAccessibility[KeychainAccessibilityKeys];
+};
 
 export type StorageErrorCallback = (error?: Error) => void;
 export type StorageValueCallback = (error?: Error, value?: string) => void;
@@ -16,7 +26,11 @@ export default class EncryptedStorage {
    * @param {string} key - A string that will be associated to the value for later retrieval.
    * @param {string} value - The data to store.
    */
-  static setItem(key: string, value: string): Promise<void>;
+  static setItem(
+    key: string,
+    value: string,
+    options?: EncryptedStorageOptions
+  ): Promise<void>;
 
   /**
    * Writes data to the disk, using SharedPreferences or KeyChain, depending on the platform.
@@ -24,66 +38,88 @@ export default class EncryptedStorage {
    * @param {string} value - The data to store.
    * @param {Function} cb - The function to call when the operation completes.
    */
-  static setItem(key: string, value: string, cb: StorageErrorCallback): void;
   static setItem(
     key: string,
     value: string,
+    options?: EncryptedStorageOptions,
+    cb?: StorageErrorCallback
+  ): void;
+  static setItem(
+    key: string,
+    value: string,
+    options?: EncryptedStorageOptions,
     cb?: StorageErrorCallback
   ): void | Promise<void> {
     if (cb) {
-      RNEncryptedStorage.setItem(key, value).then(cb).catch(cb);
+      RNEncryptedStorage.setItem(key, value, options).then(cb).catch(cb);
       return;
     }
 
-    return RNEncryptedStorage.setItem(key, value);
+    return RNEncryptedStorage.setItem(key, value, options);
   }
 
   /**
    * Retrieves data from the disk, using SharedPreferences or KeyChain, depending on the platform and returns it as the specified type.
    * @param {string} key - A string that is associated to a value.
    */
-  static getItem(key: string): Promise<string | null>;
+  static getItem(
+    key: string,
+    options?: EncryptedStorageOptions
+  ): Promise<string | null>;
 
   /**
    * Retrieves data from the disk, using SharedPreferences or KeyChain, depending on the platform and returns it as the specified type.
    * @param {string} key - A string that is associated to a value.
    * @param {Function} cb - The function to call when the operation completes.
    */
-  static getItem(key: string, cb: StorageValueCallback): void;
   static getItem(
     key: string,
+    options?: EncryptedStorageOptions,
+    cb?: StorageValueCallback
+  ): void;
+  static getItem(
+    key: string,
+    options?: EncryptedStorageOptions,
     cb?: StorageValueCallback
   ): void | Promise<string | null> {
     if (cb) {
-      RNEncryptedStorage.getItem(key).then(cb).catch(cb);
+      RNEncryptedStorage.getItem(key, options).then(cb).catch(cb);
       return;
     }
 
-    return RNEncryptedStorage.getItem(key);
+    return RNEncryptedStorage.getItem(key, options);
   }
 
   /**
    * Deletes data from the disk, using SharedPreferences or KeyChain, depending on the platform.
    * @param {string} key - A string that is associated to a value.
    */
-  static removeItem(key: string): Promise<void>;
+  static removeItem(
+    key: string,
+    options?: EncryptedStorageOptions
+  ): Promise<void>;
 
   /**
    * Deletes data from the disk, using SharedPreferences or KeyChain, depending on the platform.
    * @param {string} key - A string that is associated to a value.
    * @param {Function} cb - The function to call when the operation completes.
    */
-  static removeItem(key: string, cb: StorageErrorCallback): void;
   static removeItem(
     key: string,
+    options?: EncryptedStorageOptions,
+    cb?: StorageErrorCallback
+  ): void;
+  static removeItem(
+    key: string,
+    options?: EncryptedStorageOptions,
     cb?: StorageErrorCallback
   ): void | Promise<void> {
     if (cb) {
-      RNEncryptedStorage.removeItem(key).then(cb).catch(cb);
+      RNEncryptedStorage.removeItem(key, options).then(cb).catch(cb);
       return;
     }
 
-    return RNEncryptedStorage.removeItem(key);
+    return RNEncryptedStorage.removeItem(key, options);
   }
 
   /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,28 @@
+/**
+ * Values you use with the `kSecAttrAccessible` attribute key, listed from most to least restrictive.
+ */
+export const keychainAccessibility = {
+  /**
+   * The data in the keychain can only be accessed when the device is unlocked. Only available if a passcode is set on the device.
+   */
+  kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly:
+    'kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly',
+  /**
+   * The data in the keychain item can be accessed only while the device is unlocked by the user.
+   */
+  kSecAttrAccessibleWhenUnlockedThisDeviceOnly:
+    'kSecAttrAccessibleWhenUnlockedThisDeviceOnly',
+  /**
+   * The data in the keychain item can be accessed only while the device is unlocked by the user.
+   */
+  kSecAttrAccessibleWhenUnlocked: 'kSecAttrAccessibleWhenUnlocked',
+  /**
+   * The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user.
+   */
+  kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly:
+    'kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly',
+  /**
+   * The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user.
+   */
+  kSecAttrAccessibleAfterFirstUnlock: 'kSecAttrAccessibleAfterFirstUnlock',
+} as const;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 /**
  * Values you use with the `kSecAttrAccessible` attribute key, listed from most to least restrictive.
  */
-export const keychainAccessibility = {
+export const KeychainAccessibility = {
   /**
    * The data in the keychain can only be accessed when the device is unlocked. Only available if a passcode is set on the device.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { default } from './EncryptedStorage';
+export { EncryptedStorageOptions } from './EncryptedStorage';
 export * from './constants';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { default } from './EncryptedStorage';
+export * from './constants';


### PR DESCRIPTION
Hi @emeraldsanto, thank you for this great library! This PR adds support for storage options, namely:
- `keychainAccessibility` on iOS, via [kSecAttrAccessible](https://developer.apple.com/documentation/security/ksecattraccessible?language=objc)
- `storageName`, which uses  [kSecAttrService](https://developer.apple.com/documentation/security/ksecattrservice?language=objc) on iOS and [fileName](https://developer.android.com/reference/kotlin/androidx/security/crypto/EncryptedSharedPreferences?hl=en#create) on Android

Both are optional and have sensible defaults (which we can change if you think it's required).

In terms of the API, I added an `options` object as the previous to last parameter to all methods (before the optional `cb`). 

```js
import EncryptedStorage, {
  KeychainAccessibility,
} from 'react-native-encrypted-storage'

await EncryptedStorage.setItem(key, value, {
    storageName: 'myStorage',
    keychainAccessibility: KeychainAccessibility.kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
})
```

Following semver, this would be a breaking change in the function signature, so I suppose it requires a major version bump (if you agree with the API / approach). 

Please let me know what you think.