### PR TITLE
Docs: Add Keychain sharing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ static void ClearKeychainIfNecessary() {
 
 @end
 ```
+### Sharing the `Keychain` with app extensions
+You'll need to enable the Keychain Sharing entitlement in the `Signing & Capabilities` section of your build target
 
 # Limitations
 


### PR DESCRIPTION
I originally asked if it was possible to share the storage with app extensions here:

https://github.com/emeraldsanto/react-native-encrypted-storage/issues/93

I updated the docs with the steps necessary to do so.