### PR TITLE
maintenance: removed jCenter in favour of Maven Central

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   repositories {
+    mavenCentral()
     google()
-    jcenter()
   }
 
   dependencies {
@@ -48,7 +48,6 @@ android {
 
 repositories {
   mavenCentral()
-  jcenter()
   google()
 
   def found = false


### PR DESCRIPTION
Jcenter has gone offline, and the dependency on it should be removed.